### PR TITLE
Make parameter classes public

### DIFF
--- a/src/main/java/codes/rafael/modulemaker/Provide.java
+++ b/src/main/java/codes/rafael/modulemaker/Provide.java
@@ -3,7 +3,7 @@ package codes.rafael.modulemaker;
 /**
  * A description of a service provider.
  */
-class Provide {
+public class Provide {
 
     /**
      * A comma-separated list of provided services.

--- a/src/main/java/codes/rafael/modulemaker/QualifiedPackage.java
+++ b/src/main/java/codes/rafael/modulemaker/QualifiedPackage.java
@@ -3,7 +3,7 @@ package codes.rafael.modulemaker;
 /**
  * A description of a qualified export or opening.
  */
-class QualifiedPackage {
+public class QualifiedPackage {
 
     /**
      * A comma-separated list of exported or opened packages.


### PR DESCRIPTION
Maven cannot instantiate non-public parameter classes.

Using this configuration resulted in a build error:

```
<configuration>
 ...
  <provides>
    <provide>
      <services>com.example.MyService</services>
      <providers>com.example.MyServiceImpl</providers>
    </provide>
  </provides>
</configuration>
```

The error message was:
```
[ERROR] Failed to execute goal codes.rafael.modulemaker:modulemaker-maven-plugin:1.1:make-module (default) on project my-project: Unable to parse configuration of mojo codes.rafael.modulemaker:modulemaker-maven-plugin:1.1:make-module for parameter provide: Cannot create instance of class codes.rafael.modulemaker.Provide: class org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter cannot access a member of class codes.rafael.modulemaker.Provide with modifiers "" -> [Help 1]
```