### PR TITLE
Change scope of Maven Plugin API Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${version.maven}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Change the scope of the maven-plugin-api to provided.

When building with Maven 3.9.2 with `-Dmaven.plugin.validation=VERBOSE` I get the following warning:

```
WARNING] Plugin validation issues were detected in 5 plugin(s)
[WARNING] 
[WARNING]  * org.apache.maven.plugins:maven-jar-plugin:3.0.2
...
[WARNING]    * Plugin should declare these Maven artifacts in `provided` scope: [org.apache.maven:maven-settings-builder:3.0, org.apache.maven:maven-repository-metadata:3.0, org.apache.maven:maven-artifact:3.0, org.apache.maven:maven-plugin-api:3.0, org.apache.maven:maven-settings:3.0, org.apache.maven:maven-aether-provider:3.0, org.apache.maven:maven-model:3.0, org.apache.maven:maven-core:3.0, org.apache.maven:maven-model-builder:3.0]
```